### PR TITLE
Fixes sequence handling problem when a slug is a substring of another slug

### DIFF
--- a/lib/slug/slug.rb
+++ b/lib/slug/slug.rb
@@ -1,6 +1,6 @@
 module Slug
   module ClassMethods
-    
+
     # Call this to set up slug handling on an ActiveRecord model.
     #
     # Params:
@@ -11,34 +11,34 @@ module Slug
     # * <tt>:validate_uniquness_if</tt> - proc to determine whether uniqueness validation runs, same format as validates_uniquness_of :if
     #
     # Slug will take care of validating presence and uniqueness of slug.
-    
+
     # Before create, Slug will generate and assign the slug if it wasn't explicitly set.
     # Note that subsequent changes to the source column will have no effect on the slug.
     # If you'd like to update the slug later on, call <tt>@model.set_slug</tt>
     def slug source, opts={}
       class_inheritable_accessor :slug_source, :slug_column
       include InstanceMethods
-      
+
       self.slug_source = source
-      
+
       self.slug_column = opts.has_key?(:column) ? opts[:column] : :slug
 
       uniqueness_opts = {}
       uniqueness_opts[:if] = opts[:validate_uniqueness_if] if opts.key?(:validate_uniqueness_if)
-      
+
       validates                 self.slug_column, :presence => { :message => "cannot be blank. Is #{self.slug_source} sluggable?" }
       validates                 self.slug_column, :uniqueness => uniqueness_opts
       validates                 self.slug_column, :format => { :with => /^[a-z0-9-]+$/, :message => "contains invalid characters. Only downcase letters, numbers, and '-' are allowed." }
       before_validation :set_slug, :on => :create
     end
   end
-  
+
   module InstanceMethods
-  
+
     # Sets the slug. Called before create.
     # By default, set_slug won't change slug if one already exists.  Pass :force => true to overwrite.
     def set_slug(opts={})
-      validate_slug_columns      
+      validate_slug_columns
       return unless self[self.slug_column].blank? || opts[:force] == true
 
       original_slug = self[self.slug_column]
@@ -48,21 +48,21 @@ module Slug
       normalize_slug
       assign_slug_sequence unless self[self.slug_column] == original_slug # don't try to increment seq if slug hasn't changed
     end
-  
+
     # Overwrite existing slug based on current contents of source column.
     def reset_slug
       set_slug(:force => true)
     end
-  
+
     # Overrides to_param to return the model's slug.
     def to_param
       self[self.slug_column]
     end
-  
+
     def self.included(klass)
       klass.extend(ClassMethods)
     end
-  
+
     private
     # Validates that source and destination methods exist. Invoked at runtime to allow definition
     # of source/slug methods after <tt>slug</tt> setup in class.
@@ -70,7 +70,7 @@ module Slug
       raise ArgumentError, "Source column '#{self.slug_source}' does not exist!" if !self.respond_to?(self.slug_source)
       raise ArgumentError, "Slug column '#{self.slug_column}' does not exist!"   if !self.respond_to?("#{self.slug_column}=")
     end
-    
+
     # Takes the slug, downcases it and replaces non-word characters with a -.
     # Feel free to override this method if you'd like different slug formatting.
     def normalize_slug
@@ -84,7 +84,7 @@ module Slug
       s.gsub!(/-+/, '-')      # get rid of double-dashes
       self[self.slug_column] = s.to_s
     end
-  
+
     # Converts accented characters to their ASCII equivalents and removes them if they have no equivalent.
     # Override this with a void function if you don't want accented characters to be stripped.
     def strip_diacritics_from_slug
@@ -102,7 +102,7 @@ module Slug
       s = s.pack('U*')
       self[self.slug_column] = s.to_s
     end
-  
+
     # If a slug of the same name already exists, this will append '-n' to the end of the slug to
     # make it unique. The second instance gets a '-1' suffix.
     def assign_slug_sequence
@@ -110,16 +110,16 @@ module Slug
       idx = next_slug_sequence
       self[self.slug_column] = "#{self[self.slug_column]}-#{idx}" if idx > 0
     end
-  
+
     # Returns the next unique index for a slug.
     def next_slug_sequence
-      last_in_sequence = self.class.where("#{self.slug_column} LIKE ?", self[self.slug_column] + '%').order("CAST(REPLACE(#{self.slug_column},'#{self[self.slug_column]}-','') AS UNSIGNED) DESC").first
-      if last_in_sequence.nil?
-        return 0
+      last_in_sequence = self.class.where("#{self.slug_column} LIKE ?", self[self.slug_column] + '%').order("CAST(REPLACE(#{self.slug_column},'#{self[self.slug_column]}-','') AS UNSIGNED) DESC, #{self.slug_column} ASC").first
+      return 0 if last_in_sequence.nil?
+      sequence_match = last_in_sequence[self.slug_column].match(/^#{self[self.slug_column]}(-(\d+))?$/)
+      if sequence_match.nil?
+        last_in_sequence[self.slug_column] == self[self.slug_column] ? 1 : 0
       else
-        sequence_match = last_in_sequence[self.slug_column].match(/^#{self[self.slug_column]}(-(\d+))?/)
-        current = sequence_match.nil? ? 0 : sequence_match[2].to_i
-        return current + 1
+        sequence_match[2].to_i + 1
       end
     end
   end

--- a/test/test_slug.rb
+++ b/test/test_slug.rb
@@ -22,7 +22,7 @@ class TestSlug < Test::Unit::TestCase
       article = Article.create!(:headline => 'Test Headline')
       assert_equal 'test-headline', article.slug
     end
-    
+
     should "save slug to :column specified in options" do
       person = Person.create!(:name => 'Test Person')
       assert_equal 'test-person', person.web_slug
@@ -31,7 +31,7 @@ class TestSlug < Test::Unit::TestCase
 
   context "column validations" do
     should "raise ArgumentError if an invalid source column is passed" do
-      Company.slug(:invalid_source_column) 
+      Company.slug(:invalid_source_column)
       assert_raises(ArgumentError) { Company.create! }
     end
 
@@ -40,20 +40,20 @@ class TestSlug < Test::Unit::TestCase
       assert_raises(ArgumentError) { Company.create! }
     end
   end
-  
+
   should "set validation error if source column is empty" do
     article = Article.create
     assert !article.valid?
     require 'ruby-debug'
     assert article.errors[:slug]
   end
-  
+
   should "set validation error if normalization makes source value empty" do
     article = Article.create(:headline => '$$$')
     assert !article.valid?
     assert article.errors[:slug]
   end
-  
+
   should "not update the slug even if the source column changes" do
     article = Article.create!(:headline => 'Test Headline')
     article.update_attributes!(:headline =>  'New Headline')
@@ -67,12 +67,12 @@ class TestSlug < Test::Unit::TestCase
     assert !article.valid?
     assert article.errors[:slug].present?
   end
-  
+
   should "validate uniqueness of slug by default" do
     article1 = Article.create!(:headline => 'Test Headline')
     article2 = Article.create!(:headline => 'Test Headline')
     article2.slug = 'test-headline'
-    
+
     assert !article2.valid?
     assert article2.errors[:slug].present?
   end
@@ -81,7 +81,7 @@ class TestSlug < Test::Unit::TestCase
     article1 = Post.create!(:headline => 'Test Headline')
     article2 = Post.new
     article2.slug = 'test-headline'
-    
+
     assert article2.valid?
   end
 
@@ -91,33 +91,33 @@ class TestSlug < Test::Unit::TestCase
   end
 
   context "resetting a slug" do
-  
+
     setup do
       @article = Article.create(:headline => 'test headline')
       @original_slug = @article.slug
     end
-    
+
     should "maintain the same slug if slug column hasn't changed" do
       @article.reset_slug
-      assert_equal @original_slug, @article.slug      
+      assert_equal @original_slug, @article.slug
     end
-    
+
     should "change slug if slug column has updated" do
       @article.headline = "donkey"
       @article.reset_slug
       assert_not_equal @original_slug, @article.slug
     end
-    
+
     should "maintain sequence" do
       @existing_article = Article.create!(:headline => 'world cup')
       @article.headline = "world cup"
       @article.reset_slug
       assert_equal 'world-cup-1', @article.slug
     end
-  
+
   end
-  
-  
+
+
   context "slug normalization" do
     setup do
       @article = Article.new
@@ -128,7 +128,7 @@ class TestSlug < Test::Unit::TestCase
       @article.save!
       assert_equal "abc", @article.slug
     end
-  
+
     should "should replace whitespace with dashes" do
       @article.headline = 'a b'
       @article.save!
@@ -146,7 +146,7 @@ class TestSlug < Test::Unit::TestCase
       @article.save!
       assert_match 'abc', @article.slug
     end
-  
+
     should "should strip trailing space" do
       @article.headline = 'ab '
       @article.save!
@@ -158,7 +158,7 @@ class TestSlug < Test::Unit::TestCase
       @article.save!
       assert_equal 'ab', @article.slug
     end
-      
+
     should "should strip trailing dashes" do
       @article.headline = 'ab-'
       @article.save!
@@ -182,37 +182,37 @@ class TestSlug < Test::Unit::TestCase
       @article.save!
       assert_match 'a-b-c-d', @article.slug
     end
-    
+
     should "not insert dashes for periods in acronyms, regardless of where they appear in string" do
       @article.headline = "N.Y.P.D. vs. N.S.A. vs. F.B.I."
       @article.save!
       assert_match 'nypd-vs-nsa-vs-fbi', @article.slug
     end
-    
+
     should "not insert dashes for apostrophes" do
       @article.headline = "Thomas Jefferson's Papers"
       @article.save!
       assert_match 'thomas-jeffersons-papers', @article.slug
     end
-    
+
     should "preserve numbers in slug" do
       @article.headline = "2010 Election"
       @article.save!
       assert_match '2010-election', @article.slug
     end
   end
-  
+
   context "diacritics handling" do
     setup do
       @article = Article.new
     end
-  
+
     should "should strip diacritics" do
       @article.headline = "açaí"
       @article.save!
       assert_equal "acai", @article.slug
     end
-  
+
     should "strip diacritics correctly " do
       @article.headline  = "ÀÁÂÃÄÅÆÇÈÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõöøùúûüýþÿ"
       @article.save!
@@ -229,22 +229,42 @@ class TestSlug < Test::Unit::TestCase
       article = Article.create!(:headline => 'Test Headline')
       assert_equal 'test-headline', article.slug
     end
-    
+
+    should "not add a sequence if saving first instance of slug which is a substring of another slug" do
+      Article.create!(:headline => 'Test Headline')
+      article = Article.create!(:headline => 'Test Head')
+      assert_equal 'test-head', article.slug
+    end
+
+    should "add a sequence if saving second instance of slug which is substring of another slug" do
+      Article.create!(:headline => 'Test Headline')
+      Article.create!(:headline => 'Test Head')
+      Article.create!(:headline => 'Test')
+      article = Article.create!(:headline => 'Test Head')
+      assert_equal 'test-head-1', article.slug
+    end
+
+    should "add a sequence if saving first instance of slug which already exists" do
+      Article.create!(:headline => 'Formula 1')
+      article = Article.create!(:headline => 'Formula')
+      assert_equal 'formula-2', article.slug
+    end
+
     should "assign a -1 suffix to the second instance of the slug" do
       article_1 = Article.create!(:headline => 'Test Headline')
       article_2 = Article.create!(:headline => 'Test Headline')
       assert_equal 'test-headline-1', article_2.slug
     end
-    
+
     should "assign a -12 suffix to the thirteenth instance of the slug" do
       12.times { |i| Article.create!(:headline => 'Test Headline') }
       article_13 = Article.create!(:headline => 'Test Headline')
       assert_equal 'test-headline-12', article_13.slug
-      
+
       12.times { |i| Article.create!(:headline => 'latest from lybia') }
       article_13 = Article.create!(:headline => 'latest from lybia')
       assert_equal 'latest-from-lybia-12', article_13.slug
-    end    
+    end
   end
 
 end


### PR DESCRIPTION
When creating a slug which is a sub-string of an existing slug, the existing slug is considered a match and therefore a '-1' is added to the slug. 

For example, if the sub-string "test-example" already exists, when creating another record with slug "test", a "-1" is appended to it creating "test-1". See the included tests for working examples.
