### PR TITLE
avoid using multiline anchors when validating

### DIFF
--- a/lib/slug/slug.rb
+++ b/lib/slug/slug.rb
@@ -28,7 +28,7 @@ module Slug
       
       validates                 self.slug_column, :presence => { :message => "cannot be blank. Is #{self.slug_source} sluggable?" }
       validates                 self.slug_column, :uniqueness => uniqueness_opts
-      validates                 self.slug_column, :format => { :with => /^[a-z0-9-]+$/, :message => "contains invalid characters. Only downcase letters, numbers, and '-' are allowed." }
+      validates                 self.slug_column, :format => { :with => /\A[a-z0-9-]+\z/, :message => "contains invalid characters. Only downcase letters, numbers, and '-' are allowed." }
       before_validation :set_slug, :on => :create
     end
   end


### PR DESCRIPTION
Resolves an ActiveModel error in Rails 4 (https://github.com/rails/rails/blob/4-0-stable/activemodel/CHANGELOG.md).
