### PR TITLE
Repair error of to_param when no slug column

### DIFF
--- a/lib/slug/slug.rb
+++ b/lib/slug/slug.rb
@@ -36,63 +36,66 @@ module Slug
         with: /\A[a-z0-9-]+\z/,
         message: "contains invalid characters. Only downcase letters, numbers, and '-' are allowed."
       before_validation :set_slug, :on => :create
+
+      include SlugInstanceMethods
     end
   end
 
-  # Sets the slug. Called before create.
-  # By default, set_slug won't change slug if one already exists.  Pass :force => true to overwrite.
-  def set_slug(opts={})
-    validate_slug_columns
-    return if self[self.slug_column].present? && !opts[:force]
+  module SlugInstanceMethods
+    # Sets the slug. Called before create.
+    # By default, set_slug won't change slug if one already exists.  Pass :force => true to overwrite.
+    def set_slug(opts={})
+      validate_slug_columns
+      return if self[self.slug_column].present? && !opts[:force]
 
-    self[self.slug_column] = normalize_slug(self.send(self.slug_source))
+      self[self.slug_column] = normalize_slug(self.send(self.slug_source))
 
-    # if normalize_slug returned a blank string, try the generic_default handling
-    if generic_default && self[self.slug_column].blank?
-      self[self.slug_column] = self.class.to_s.demodulize.underscore.dasherize
+      # if normalize_slug returned a blank string, try the generic_default handling
+      if generic_default && self[self.slug_column].blank?
+        self[self.slug_column] = self.class.to_s.demodulize.underscore.dasherize
+      end
+
+      assign_slug_sequence if self.changed_attributes.include?(self.slug_column)
     end
 
-    assign_slug_sequence if self.changed_attributes.include?(self.slug_column)
-  end
+    # Overwrite existing slug based on current contents of source column.
+    def reset_slug
+      set_slug(:force => true)
+    end
 
-  # Overwrite existing slug based on current contents of source column.
-  def reset_slug
-    set_slug(:force => true)
-  end
+    # Overrides to_param to return the model's slug.
+    def to_param
+      self[self.slug_column]
+    end
 
-  # Overrides to_param to return the model's slug.
-  def to_param
-    self[self.slug_column]
-  end
+    private
+    # Validates that source and destination methods exist. Invoked at runtime to allow definition
+    # of source/slug methods after <tt>slug</tt> setup in class.
+    def validate_slug_columns
+      raise ArgumentError, "Source column '#{self.slug_source}' does not exist!" if !self.respond_to?(self.slug_source)
+      raise ArgumentError, "Slug column '#{self.slug_column}' does not exist!"   if !self.respond_to?("#{self.slug_column}=")
+    end
 
-  private
-  # Validates that source and destination methods exist. Invoked at runtime to allow definition
-  # of source/slug methods after <tt>slug</tt> setup in class.
-  def validate_slug_columns
-    raise ArgumentError, "Source column '#{self.slug_source}' does not exist!" if !self.respond_to?(self.slug_source)
-    raise ArgumentError, "Slug column '#{self.slug_column}' does not exist!"   if !self.respond_to?("#{self.slug_column}=")
-  end
+    # Takes the slug, downcases it and replaces non-word characters with a -.
+    # Feel free to override this method if you'd like different slug formatting.
+    def normalize_slug(str)
+      return if str.blank?
+      str.gsub!(/[\p{Pc}\p{Ps}\p{Pe}\p{Pi}\p{Pf}\p{Po}]/, '') # Remove punctuation
+      str.parameterize
+    end
 
-  # Takes the slug, downcases it and replaces non-word characters with a -.
-  # Feel free to override this method if you'd like different slug formatting.
-  def normalize_slug(str)
-    return if str.blank?
-    str.gsub!(/[\p{Pc}\p{Ps}\p{Pe}\p{Pi}\p{Pf}\p{Po}]/, '') # Remove punctuation
-    str.parameterize
-  end
+    # If a slug of the same name already exists, this will append '-n' to the end of the slug to
+    # make it unique. The second instance gets a '-1' suffix.
+    def assign_slug_sequence
+      return if self[self.slug_column].blank?
+      assoc = self.class.base_class
+      base_slug = self[self.slug_column]
+      seq = 0
 
-  # If a slug of the same name already exists, this will append '-n' to the end of the slug to
-  # make it unique. The second instance gets a '-1' suffix.
-  def assign_slug_sequence
-    return if self[self.slug_column].blank?
-    assoc = self.class.base_class
-    base_slug = self[self.slug_column]
-    seq = 0
-
-    while assoc.where(self.slug_column => self[self.slug_column]).exists? do
-      seq += 1
-      self[self.slug_column] = "#{base_slug}-#{seq}"
+      while assoc.where(self.slug_column => self[self.slug_column]).exists? do
+        seq += 1
+        self[self.slug_column] = "#{base_slug}-#{seq}"
+      end
     end
   end
-
 end

--- a/test/models.rb
+++ b/test/models.rb
@@ -34,3 +34,6 @@ class Generation < ActiveRecord::Base
   slug :title, generic_default: true
 end
 
+# Test model with no slug column
+class Orphan < ActiveRecord::Base
+end

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -32,4 +32,10 @@ ActiveRecord::Schema.define(:version => 1) do
     t.column "title", "string"
     t.column "slug", "string", null: false
   end
+
+  # table with no slug column
+  create_table "orphans", :force => true do |t|
+    t.column "name", "string"
+    t.column "location", "string"
+  end
 end

--- a/test/slug_test.rb
+++ b/test/slug_test.rb
@@ -17,10 +17,15 @@ describe Slug do
       assert_equal 'test-event-portland', article.slug
     end
 
+    it "bases to_param on slug" do
+      article = Article.create!(:headline => 'Test Headline')
+      assert_equal(article.slug, article.to_param)
+    end
+
     it "does not impact lookup of model with no slug column" do
       orphan = Orphan.create!(:name => 'Oliver')
       query = orphan.to_param
-      assert_equal(orphan.id, query)
+      assert_equal(orphan.id.to_s, query)
     end
 
     describe "slug column" do

--- a/test/slug_test.rb
+++ b/test/slug_test.rb
@@ -17,6 +17,12 @@ describe Slug do
       assert_equal 'test-event-portland', article.slug
     end
 
+    it "does not impact lookup of model with no slug column" do
+      orphan = Orphan.create!(:name => 'Oliver')
+      query = orphan.to_param
+      assert_equal(orphan.id, query)
+    end
+
     describe "slug column" do
       it "saves slug to 'slug' column by default" do
         article = Article.create!(:headline => 'Test Headline')


### PR DESCRIPTION
This is to repair [issue 20](https://github.com/bkoski/slug/issues/20)

It adds two tests for the `to_param` instance method:
- one which ensures override when there is a slug
- the other ensures no change in behavior on models without a slug

The fix proposed and imlemented here is to extend models with the slug instance methods only when `slug` is invoked at the class level.